### PR TITLE
Add Ecommerce Profit Tracker PRO to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A curated list of awesome Microsoft Excel resources
 - [Microsoft Excel Addin Store](https://appsource.microsoft.com/en-us/marketplace/apps?src=office&page=1&product=office%3Bexcel) - An online catalog for Excel addins
 - [ASAP Utilities](https://www.asap-utilities.com/) - A popular Excel addin that adds various handy features to Excel.
 - [CustomFormats.com](https://customformats.com) - An online scratchpad for building custom formats for Excel and Google Sheets.
+- [Ecommerce Profit Tracker PRO](https://whop.com/glm-643b/ecommerce-profit-tracker-pro-know-your-real-profit) - A ready-to-use Excel/Google Sheets workbook for ecommerce sellers (Etsy, Shopify, Amazon, eBay). Calculates true net profit per order after fees, ad spend and COGS. 7 worksheets, pure formulas, no macros.
 
 ## Learning
 - [Spreadsheet Tips](https://gridmaster.io/tips) - An animated spreadsheet tip sent to your inbox each week.


### PR DESCRIPTION
## What

Adds **Ecommerce Profit Tracker PRO** to the Tools section, after CustomFormats.com.

## Why it fits

The Tools section already lists distributable Excel/Google Sheets utilities (Microsoft Addin Store, ASAP Utilities, CustomFormats.com). Ecommerce Profit Tracker PRO is another distributable Excel/Google Sheets tool — a 7-worksheet template for ecommerce sellers. It calculates true net profit per order after marketplace fees, ad spend and COGS. One-time $19, non-affiliate, built by me.

Follows the existing list style: `- [Name](url) - Description.`

Happy to adjust wording. Thanks for maintaining this list!